### PR TITLE
fix: Added PAYMENT_CARD payment method and remapping logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
 			<version>1.72</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/bean/ClosePaymentRequest.java
+++ b/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/bean/ClosePaymentRequest.java
@@ -35,7 +35,7 @@ public class ClosePaymentRequest {
 	 * Method used to pay notice/s
 	 */
 	@NotNull(message = "[" + ErrorCode.ERROR_PAYMENT_METHOD_MUST_NOT_BE_NULL + "] paymentMethod must not be null")
-	@Pattern(regexp = "PAGOBANCOMAT|DEBIT_CARD|CREDIT_CARD|BANK_ACCOUNT|CASH", message = "[" + ErrorCode.ERROR_PAYMENT_METHOD_MUST_MATCH_REGEXP + "] paymentMethod must match \"{regexp}\"")
+	@Pattern(regexp = "PAGOBANCOMAT|DEBIT_CARD|CREDIT_CARD|PAYMENT_CARD|BANK_ACCOUNT|CASH", message = "[" + ErrorCode.ERROR_PAYMENT_METHOD_MUST_MATCH_REGEXP + "] paymentMethod must match \"{regexp}\"")
 	private String paymentMethod;
 
 	/**

--- a/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/bean/PaymentMethod.java
+++ b/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/bean/PaymentMethod.java
@@ -7,6 +7,7 @@ public enum PaymentMethod {
 	PAGOBANCOMAT,
     DEBIT_CARD,
     CREDIT_CARD,
+    PAYMENT_CARD,
     BANK_ACCOUNT,
     CASH
 }

--- a/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/bean/VerifyPaymentNoticeResponse.java
+++ b/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/bean/VerifyPaymentNoticeResponse.java
@@ -48,12 +48,12 @@ public class VerifyPaymentNoticeResponse {
 	@JsonInclude(Include.NON_NULL)
 	private String office;
 
-	@NotNull
 	@Pattern(regexp = "^\\d{11}$")
+	@JsonInclude(Include.NON_NULL)
 	private String paTaxCode;
 
-	@NotNull
 	@Pattern(regexp = "^\\d{18}$")
+	@JsonInclude(Include.NON_NULL)
 	private String noticeNumber;
 
 

--- a/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/client/bean/AdditionalPaymentInformations.java
+++ b/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/client/bean/AdditionalPaymentInformations.java
@@ -12,4 +12,11 @@ public class AdditionalPaymentInformations {
 	public AdditionalPaymentInformations() {
 		//empty object to pass to the close payment request to the Node
 	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder("AdditionalPaymentInformations{");
+		sb.append('}');
+		return sb.toString();
+	}
 }

--- a/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/dao/PspConfRepository.java
+++ b/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/dao/PspConfRepository.java
@@ -7,7 +7,8 @@ import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoRepository;
 /**
  *  MongoDB repository to access PSP configuration data, reactive flavor
  */
-@ApplicationScoped
-public class PspConfRepository implements ReactivePanacheMongoRepository<PspConfEntity> {
 
+@ApplicationScoped
+public class PspConfRepository implements ReactivePanacheMongoRepository<PspConfEntity> { //NOSONAR
+	
 }

--- a/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/resource/FailedPaymentTransactionProcessor.java
+++ b/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/resource/FailedPaymentTransactionProcessor.java
@@ -1,5 +1,11 @@
 package it.gov.pagopa.swclient.mil.paymentnotice.resource;
 
+import java.time.Duration;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
 import io.quarkus.logging.Log;
 import io.quarkus.vertx.ConsumeEvent;
 import io.smallrye.mutiny.Uni;
@@ -8,10 +14,6 @@ import it.gov.pagopa.swclient.mil.paymentnotice.ErrorCode;
 import it.gov.pagopa.swclient.mil.paymentnotice.client.NodeRestService;
 import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.NodeClosePaymentRequest;
 import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.NodeClosePaymentResponse;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
-
-import javax.enterprise.context.ApplicationScoped;
-import java.time.Duration;
 
 @ApplicationScoped
 public class FailedPaymentTransactionProcessor {
@@ -28,7 +30,7 @@ public class FailedPaymentTransactionProcessor {
      * @param nodeClosePaymentRequest the object received in request of the closePayment
      */
     @ConsumeEvent("failedPaymentTransaction")
-    void consume(NodeClosePaymentRequest nodeClosePaymentRequest) {
+    public void consume(NodeClosePaymentRequest nodeClosePaymentRequest) {
         Log.debugf("Asynchronously process %s", nodeClosePaymentRequest);
 
         callNodeClosePayment(nodeClosePaymentRequest)
@@ -50,11 +52,13 @@ public class FailedPaymentTransactionProcessor {
     private Uni<NodeClosePaymentResponse> callNodeClosePayment(NodeClosePaymentRequest nodeClosePaymentRequest) {
         return nodeRestService.closePayment(nodeClosePaymentRequest)
                 .onItem().transform(Unchecked.function(r -> {
-                    if (r.getOutcome().equals("KO")) throw new InvalidResponseException();
+                    if (r.getOutcome().equals("KO")) {
+                    	throw new InvalidResponseException();
+                    }
                     else return r;
                 }));
     }
 
-    private static class InvalidResponseException extends Exception {
+    private class InvalidResponseException extends Exception {
     }
 }

--- a/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/resource/PaymentResource.java
+++ b/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/resource/PaymentResource.java
@@ -208,6 +208,7 @@ public class PaymentResource extends BasePaymentResource {
 				})
 				.onItem().ifNull().failWith(() -> {
 					// if no transaction is found on redis return PAYMENT_NOT_FOUND as outcome
+					Log.errorf("REDIS transactionId not found");
 					ReceivePaymentStatusResponse receiveResponse = new ReceivePaymentStatusResponse();
 					receiveResponse.setOutcome("PAYMENT_NOT_FOUND");
 					return new NotFoundException(Response.status(Status.NOT_FOUND).entity(receiveResponse).build());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -78,8 +78,8 @@ quarkus.cxf.client."nodo".service-interface=it.gov.pagopa.pagopa_api.nodeforpsp.
 # Quarkus reactive Redis client configuration
 # ------------------------------------------------------------------------------
 
-#%dev.quarkus.redis.hosts=redis://:0VB6G2yFLtHwRhUgccGNJxFs2bgFFrCwJAzCaD8Vi2U=@mil-d-redis.redis.cache.windows.net:6380
-%dev.quarkus.redis.hosts=rediss://:wCou42NVkv7H@localhost:6379
+%dev.quarkus.redis.hosts=redis://localhost:6379
+#%dev.quarkus.redis.hosts=rediss://:wCou42NVkv7H@localhost:6379
 %dev.quarkus.redis.tls.trust-all=true
 %test.quarkus.redis.hosts=redis://localhost:6379
 %prod.quarkus.redis.hosts=${redis-connection-string}
@@ -92,7 +92,7 @@ quarkus.cxf.client."nodo".service-interface=it.gov.pagopa.pagopa_api.nodeforpsp.
 %test.quarkus.rest-client.node-rest-api.url=http://localhost:8088
 %prod.quarkus.rest-client.node-rest-api.url=${node.rest-service.url}
 
-%dev.node-rest-client.apim-subscription-key=abc
+%dev.node-rest-client.apim-subscription-key=
 %test.node-rest-client.apim-subscription-key=abc
 %prod.node-rest-client.apim-subscription-key=${node-rest-client-subscription-key}
 
@@ -135,6 +135,18 @@ quarkus.cxf.client."nodo".service-interface=it.gov.pagopa.pagopa_api.nodeforpsp.
 %dev.paymentnotice.activatepayment.expiration-time=30000
 %test.paymentnotice.activatepayment.expiration-time=30000
 %prod.paymentnotice.activatepayment.expiration-time=${paymentnotice.activatepayment.expiration-time}
+
+# ------------------------------------------------------------------------------
+# Node paymentMethod remapping
+# ------------------------------------------------------------------------------
+
+node.paymentmethod.map.PAGOBANCOMAT=CP
+node.paymentmethod.map.DEBIT_CARD=CP
+node.paymentmethod.map.CREDIT_CARD=CP
+node.paymentmethod.map.PAYMENT_CARD=CP
+node.paymentmethod.map.BANK_ACCOUNT=BANK_ACCOUNT
+node.paymentmethod.map.CASH=CASH
+
 
 # ------------------------------------------------------------------------------
 # Node error remapping

--- a/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/ActivatePaymentNoticeResourceTest.java
+++ b/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/ActivatePaymentNoticeResourceTest.java
@@ -6,9 +6,11 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.smallrye.mutiny.Uni;
+import it.gov.pagopa.pagopa_api.node.nodeforpsp.ActivatePaymentNoticeV2Request;
 import it.gov.pagopa.pagopa_api.node.nodeforpsp.ActivatePaymentNoticeV2Response;
 import it.gov.pagopa.pagopa_api.node.nodeforpsp.CtTransferListPSPV2;
 import it.gov.pagopa.pagopa_api.node.nodeforpsp.CtTransferPSPV2;
+import it.gov.pagopa.pagopa_api.node.nodeforpsp.VerifyPaymentNoticeReq;
 import it.gov.pagopa.pagopa_api.xsd.common_types.v1_0.CtFaultBean;
 import it.gov.pagopa.pagopa_api.xsd.common_types.v1_0.StOutcome;
 import it.gov.pagopa.swclient.mil.paymentnotice.bean.ActivatePaymentNoticeRequest;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.math.BigDecimal;
@@ -198,7 +201,25 @@ class ActivatePaymentNoticeResourceTest {
 				response.jsonPath().getList("transfers", Transfer.class).get(1).getPaTaxCode());
 		Assertions.assertEquals(StringUtils.EMPTY, response.jsonPath().getList("transfers", Transfer.class).get(1).getCategory());
 
-		// TODO add check of clients
+		//check of milRestService clients
+		ArgumentCaptor<String> captorRequestId = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> captorAcquirerId = ArgumentCaptor.forClass(String.class);
+		
+		Mockito.verify(milRestService).getPspConfiguration(captorRequestId.capture(),captorAcquirerId.capture());
+		Assertions.assertEquals(validMilHeaders.get("RequestId"),captorRequestId.getValue());
+		Assertions.assertEquals(validMilHeaders.get("AcquirerId"),captorAcquirerId.getValue());
+		
+		//check of pnWrapper clients
+		ArgumentCaptor<ActivatePaymentNoticeV2Request> captorActivatePaymentNoticeV2Request  = ArgumentCaptor.forClass(ActivatePaymentNoticeV2Request.class);
+		Mockito.verify(pnWrapper).activatePaymentNoticeV2Async(captorActivatePaymentNoticeV2Request.capture());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForVerifyAndActivate().getBroker(),captorActivatePaymentNoticeV2Request.getValue().getIdBrokerPSP());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForVerifyAndActivate().getChannel(),captorActivatePaymentNoticeV2Request.getValue().getIdChannel());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForVerifyAndActivate().getPassword(),captorActivatePaymentNoticeV2Request.getValue().getPassword());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForVerifyAndActivate().getPsp(),captorActivatePaymentNoticeV2Request.getValue().getIdPSP());
+		Assertions.assertEquals(validActivateRequest.getIdempotencyKey(),captorActivatePaymentNoticeV2Request.getValue().getIdempotencyKey());
+		
+		Assertions.assertEquals("00000000000",captorActivatePaymentNoticeV2Request.getValue().getQrCode().getFiscalCode());
+		Assertions.assertEquals("000000000000000000",captorActivatePaymentNoticeV2Request.getValue().getQrCode().getNoticeNumber());
 	}
 
 	@ParameterizedTest
@@ -446,7 +467,25 @@ class ActivatePaymentNoticeResourceTest {
 				response.jsonPath().getList("transfers", Transfer.class).get(1).getPaTaxCode());
 		Assertions.assertEquals(StringUtils.EMPTY, response.jsonPath().getList("transfers", Transfer.class).get(1).getCategory());
 
-		// TODO add check of clients
+		//check of milRestService clients
+		ArgumentCaptor<String> captorRequestId = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> captorAcquirerId = ArgumentCaptor.forClass(String.class);
+		
+		Mockito.verify(milRestService).getPspConfiguration(captorRequestId.capture(),captorAcquirerId.capture());
+		Assertions.assertEquals(validMilHeaders.get("RequestId"),captorRequestId.getValue());
+		Assertions.assertEquals(validMilHeaders.get("AcquirerId"),captorAcquirerId.getValue());
+		
+		//check of pnWrapper clients
+		ArgumentCaptor<ActivatePaymentNoticeV2Request> captorActivatePaymentNoticeV2Request  = ArgumentCaptor.forClass(ActivatePaymentNoticeV2Request.class);
+		Mockito.verify(pnWrapper).activatePaymentNoticeV2Async(captorActivatePaymentNoticeV2Request.capture());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForVerifyAndActivate().getBroker(),captorActivatePaymentNoticeV2Request.getValue().getIdBrokerPSP());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForVerifyAndActivate().getChannel(),captorActivatePaymentNoticeV2Request.getValue().getIdChannel());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForVerifyAndActivate().getPassword(),captorActivatePaymentNoticeV2Request.getValue().getPassword());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForVerifyAndActivate().getPsp(),captorActivatePaymentNoticeV2Request.getValue().getIdPSP());
+		Assertions.assertEquals(validActivateRequest.getIdempotencyKey(),captorActivatePaymentNoticeV2Request.getValue().getIdempotencyKey());
+		
+		Assertions.assertEquals("20000000000",captorActivatePaymentNoticeV2Request.getValue().getQrCode().getFiscalCode());
+		Assertions.assertEquals("100000000000000000",captorActivatePaymentNoticeV2Request.getValue().getQrCode().getNoticeNumber());
 
 	}
 

--- a/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/ActivatePaymentNoticeResourceTest.java
+++ b/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/ActivatePaymentNoticeResourceTest.java
@@ -10,7 +10,6 @@ import it.gov.pagopa.pagopa_api.node.nodeforpsp.ActivatePaymentNoticeV2Request;
 import it.gov.pagopa.pagopa_api.node.nodeforpsp.ActivatePaymentNoticeV2Response;
 import it.gov.pagopa.pagopa_api.node.nodeforpsp.CtTransferListPSPV2;
 import it.gov.pagopa.pagopa_api.node.nodeforpsp.CtTransferPSPV2;
-import it.gov.pagopa.pagopa_api.node.nodeforpsp.VerifyPaymentNoticeReq;
 import it.gov.pagopa.pagopa_api.xsd.common_types.v1_0.CtFaultBean;
 import it.gov.pagopa.pagopa_api.xsd.common_types.v1_0.StOutcome;
 import it.gov.pagopa.swclient.mil.paymentnotice.bean.ActivatePaymentNoticeRequest;

--- a/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/ClosePaymentResourceTest.java
+++ b/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/ClosePaymentResourceTest.java
@@ -1,25 +1,16 @@
 package it.gov.pagopa.swclient.mil.paymentnotice;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
-import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectMock;
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-import io.smallrye.mutiny.Uni;
-import it.gov.pagopa.swclient.mil.paymentnotice.bean.ClosePaymentRequest;
-import it.gov.pagopa.swclient.mil.paymentnotice.bean.Outcome;
-import it.gov.pagopa.swclient.mil.paymentnotice.bean.PaymentMethod;
-import it.gov.pagopa.swclient.mil.paymentnotice.bean.ReceivePaymentStatusRequest;
-import it.gov.pagopa.swclient.mil.paymentnotice.client.MilRestService;
-import it.gov.pagopa.swclient.mil.paymentnotice.client.NodeRestService;
-import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.AcquirerConfiguration;
-import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.NodeClosePaymentRequest;
-import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.NodeClosePaymentResponse;
-import it.gov.pagopa.swclient.mil.paymentnotice.redis.PaymentService;
-import it.gov.pagopa.swclient.mil.paymentnotice.resource.PaymentResource;
-import it.gov.pagopa.swclient.mil.paymentnotice.util.ExceptionType;
-import it.gov.pagopa.swclient.mil.paymentnotice.util.PaymentTestData;
-import it.gov.pagopa.swclient.mil.paymentnotice.util.TestUtils;
+import static io.restassured.RestAssured.given;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.junit.jupiter.api.Assertions;
@@ -32,16 +23,29 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Map;
-import java.util.concurrent.TimeoutException;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
 
-import static io.restassured.RestAssured.given;
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.smallrye.mutiny.Uni;
+import it.gov.pagopa.swclient.mil.paymentnotice.bean.ClosePaymentRequest;
+import it.gov.pagopa.swclient.mil.paymentnotice.bean.Outcome;
+import it.gov.pagopa.swclient.mil.paymentnotice.bean.ReceivePaymentStatusRequest;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.MilRestService;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.NodeRestService;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.AcquirerConfiguration;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.NodeClosePaymentRequest;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.NodeClosePaymentResponse;
+import it.gov.pagopa.swclient.mil.paymentnotice.redis.PaymentService;
+import it.gov.pagopa.swclient.mil.paymentnotice.resource.PaymentResource;
+import it.gov.pagopa.swclient.mil.paymentnotice.util.ExceptionType;
+import it.gov.pagopa.swclient.mil.paymentnotice.util.PaymentTestData;
+import it.gov.pagopa.swclient.mil.paymentnotice.util.TestUtils;
 
 @QuarkusTest
 @TestHTTPEndpoint(PaymentResource.class)
@@ -87,10 +91,6 @@ class ClosePaymentResourceTest {
 	@Test
 	void testClosePayment_200_node200_OK() {
 
-		Mockito
-				.when(paymentService.set(Mockito.any(String.class), Mockito.any()))
-				.thenReturn(Uni.createFrom().voidItem());
-
 		NodeClosePaymentResponse nodeClosePaymentResponse = new NodeClosePaymentResponse();
 		nodeClosePaymentResponse.setOutcome(Outcome.OK.name());
 
@@ -122,8 +122,28 @@ class ClosePaymentResourceTest {
 	    Assertions.assertNotNull(response.getHeader("Retry-after"));
 	    Assertions.assertNotNull(response.getHeader("Max-Retry"));
 
-		// TODO add check of clients
-
+		//check of milRestService clients
+		ArgumentCaptor<String> captorRequestId = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> captorAcquirerId = ArgumentCaptor.forClass(String.class);
+		
+		Mockito.verify(milRestService).getPspConfiguration(captorRequestId.capture(),captorAcquirerId.capture());
+		Assertions.assertEquals(commonHeaders.get("RequestId"),captorRequestId.getValue());
+		Assertions.assertEquals(commonHeaders.get("AcquirerId"),captorAcquirerId.getValue());
+		
+		//check of nodeRestService clients
+		ArgumentCaptor<NodeClosePaymentRequest> captorNodeClosePaymentRequest = ArgumentCaptor.forClass(NodeClosePaymentRequest.class);
+		Mockito.verify(nodeRestService).closePayment(captorNodeClosePaymentRequest.capture());
+		
+		Assertions.assertEquals(new BigDecimal(closePaymentRequestOK.getFee(), 2),captorNodeClosePaymentRequest.getValue().getFee());
+		Assertions.assertEquals(closePaymentRequestOK.getOutcome(),captorNodeClosePaymentRequest.getValue().getOutcome());
+		Assertions.assertEquals("CP",captorNodeClosePaymentRequest.getValue().getPaymentMethod());
+		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequestOK.getTimestampOp()).atZone(ZoneId.of("UTC"));
+		Assertions.assertEquals(timestampOperation.format(DateTimeFormatter.ISO_INSTANT),captorNodeClosePaymentRequest.getValue().getTimestampOperation());
+		Assertions.assertEquals(closePaymentRequestOK.getTransactionId(),captorNodeClosePaymentRequest.getValue().getTransactionId());
+		Assertions.assertEquals(new BigDecimal(closePaymentRequestOK.getTotalAmount(),2),captorNodeClosePaymentRequest.getValue().getTotalAmount());
+		//for test list of one element
+		Assertions.assertEquals(closePaymentRequestOK.getPaymentTokens().get(0),captorNodeClosePaymentRequest.getValue().getPaymentTokens().get(0));
+		
 	}
 
 	@Test
@@ -178,9 +198,14 @@ class ClosePaymentResourceTest {
 				.when(milRestService.getPspConfiguration(Mockito.any(String.class), Mockito.any(String.class)))
 				.thenReturn(Uni.createFrom().item(acquirerConfiguration));
 
+		javax.ws.rs.core.Response res = javax.ws.rs.core.Response
+														.status(statusCode)
+														.entity("")
+														.build();
+		
 		Mockito
-				.when(nodeRestService.closePayment(Mockito.any()))
-				.thenReturn(Uni.createFrom().failure(new ClientWebApplicationException(statusCode)));
+			.when(nodeRestService.closePayment(Mockito.any()))
+			.thenReturn(Uni.createFrom().failure(new ClientWebApplicationException(res))); 
 
 
 		Response response = given()
@@ -216,9 +241,14 @@ class ClosePaymentResourceTest {
 				.when(milRestService.getPspConfiguration(Mockito.any(String.class), Mockito.any(String.class)))
 				.thenReturn(Uni.createFrom().item(acquirerConfiguration));
 
+		javax.ws.rs.core.Response res = javax.ws.rs.core.Response
+																.status(status)
+																.entity("")
+																.build();
+		
 		Mockito
-				.when(nodeRestService.closePayment(Mockito.any()))
-				.thenReturn(Uni.createFrom().failure(() -> new ClientWebApplicationException(status)));
+			.when(nodeRestService.closePayment(Mockito.any()))
+			.thenReturn(Uni.createFrom().failure(new ClientWebApplicationException(res))); 
 
 
 		Response response = given()
@@ -484,55 +514,70 @@ class ClosePaymentResourceTest {
 				.response();
 
 		Assertions.assertEquals(202, response.statusCode());
+		
 
-		ArgumentCaptor<NodeClosePaymentRequest> captor = ArgumentCaptor.forClass(NodeClosePaymentRequest.class);
-		Mockito.verify(nodeRestService).closePayment(captor.capture());
-		Assertions.assertEquals("648fhg36s95jfg7DS",captor.getValue().getPaymentTokens().get(0));
-		Assertions.assertEquals(Outcome.KO.toString(), captor.getValue().getOutcome());
-		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getPsp(), captor.getValue().getIdPsp());
-		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getBroker(), captor.getValue().getIdBrokerPSP());
-		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getChannel(), captor.getValue().getIdChannel());
-		Assertions.assertEquals(PaymentMethod.PAGOBANCOMAT.name(), captor.getValue().getPaymentMethod());
-		Assertions.assertEquals("517a4216840E461fB011036A0fd134E1", captor.getValue().getTransactionId());
-		Assertions.assertEquals(BigDecimal.valueOf(234234).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getTotalAmount());
-		Assertions.assertEquals(BigDecimal.valueOf(897).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getFee());
+//		ArgumentCaptor<NodeClosePaymentRequest> captor = ArgumentCaptor.forClass(NodeClosePaymentRequest.class);
+//		Mockito.verify(nodeRestService).closePayment(captor.capture());
+//		Assertions.assertEquals("648fhg36s95jfg7DS",captor.getValue().getPaymentTokens().get(0));
+//		Assertions.assertEquals(Outcome.KO.toString(), captor.getValue().getOutcome());
+//		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getPsp(), captor.getValue().getIdPsp());
+//		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getBroker(), captor.getValue().getIdBrokerPSP());
+//		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getChannel(), captor.getValue().getIdChannel());
+//		Assertions.assertEquals(PaymentMethod.PAGOBANCOMAT.name(), captor.getValue().getPaymentMethod());
+//		Assertions.assertEquals("517a4216840E461fB011036A0fd134E1", captor.getValue().getTransactionId());
+//		Assertions.assertEquals(BigDecimal.valueOf(234234).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getTotalAmount());
+//		Assertions.assertEquals(BigDecimal.valueOf(897).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getFee());
+//		
+//		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequestKO.getTimestampOp()).atZone(ZoneId.of("UTC"));
+//		
+//		Assertions.assertEquals(timestampOperation.format(DateTimeFormatter.ISO_INSTANT), captor.getValue().getTimestampOperation());
+//		Assertions.assertNotNull(captor.getValue().getAdditionalPaymentInformations());
 		
-		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequestKO.getTimestampOp()).atZone(ZoneId.of("UTC"));
-		
-		Assertions.assertEquals(timestampOperation.format(DateTimeFormatter.ISO_INSTANT), captor.getValue().getTimestampOperation());
-		Assertions.assertNotNull(captor.getValue().getAdditionalPaymentInformations());
 	}
 
 
-//	@Test
-//	void testClosePaymentKO_200_nodeKO() {
-//
-//		NodeClosePaymentResponse nodeClosePaymentResponse = new NodeClosePaymentResponse();
-//		nodeClosePaymentResponse.setOutcome(Outcome.KO.name());
-//		
-//		Mockito
-//				.when(milRestService.getPspConfiguration(Mockito.any(String.class), Mockito.any(String.class)))
-//				.thenReturn(Uni.createFrom().item(acquirerConfiguration));
-//
-//		Mockito
-//				.when(nodeRestService.closePayment(Mockito.any(NodeClosePaymentRequest.class)))
-//				.thenReturn(Uni.createFrom().item(nodeClosePaymentResponse));
-//
-//
-//		Response response = given()
-//				.contentType(ContentType.JSON)
-//				.headers(commonHeaders)
-//				.and()
-//				.body(closePaymentRequestKO)
-//				.when()
-//				.post("/")
-//				.then()
-//				.extract()
-//				.response();
-//
-//		Assertions.assertEquals(202, response.statusCode());
-//
-//	}
+	@Test
+	void testClosePaymentOK_200_nodeKO() {
+
+		NodeClosePaymentResponse nodeClosePaymentResponse = new NodeClosePaymentResponse();
+		nodeClosePaymentResponse.setOutcome(Outcome.KO.name());
+		
+		Mockito
+			.when(paymentService.setIfNotExist(Mockito.any(String.class), Mockito.any(ReceivePaymentStatusRequest.class)))
+			.thenReturn(Uni.createFrom().item(Boolean.TRUE));
+		
+		Mockito
+				.when(milRestService.getPspConfiguration(Mockito.any(String.class), Mockito.any(String.class)))
+				.thenReturn(Uni.createFrom().item(acquirerConfiguration));
+
+		JsonParser jsonParser = null;
+		try {
+			jsonParser = new JsonFactory().createParser("{}");
+		} catch (JsonParseException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		
+		Mockito
+				.when(nodeRestService.closePayment(Mockito.any(NodeClosePaymentRequest.class)))
+				.thenReturn(Uni.createFrom().failure(new ClientWebApplicationException(new JsonParseException(jsonParser,""))));
+
+
+		Response response = given()
+				.contentType(ContentType.JSON)
+				.headers(commonHeaders)
+				.and()
+				.body(closePaymentRequestOK)
+				.when()
+				.post("/")
+				.then()
+				.extract()
+				.response();
+
+		Assertions.assertEquals(200, response.statusCode());
+
+	}
 	
 
 	

--- a/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/FailedPaymentTransactionProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/FailedPaymentTransactionProcessorTest.java
@@ -1,0 +1,157 @@
+/**
+ * 
+ */
+package it.gov.pagopa.swclient.mil.paymentnotice;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.smallrye.mutiny.Uni;
+import it.gov.pagopa.swclient.mil.paymentnotice.bean.ClosePaymentRequest;
+import it.gov.pagopa.swclient.mil.paymentnotice.bean.Outcome;
+import it.gov.pagopa.swclient.mil.paymentnotice.bean.PaymentMethod;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.NodeRestService;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.AcquirerConfiguration;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.AdditionalPaymentInformations;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.NodeClosePaymentRequest;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.NodeClosePaymentResponse;
+import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.PspConfiguration;
+import it.gov.pagopa.swclient.mil.paymentnotice.resource.FailedPaymentTransactionProcessor;
+import it.gov.pagopa.swclient.mil.paymentnotice.util.PaymentTestData;
+
+@QuarkusTest
+class FailedPaymentTransactionProcessorTest {
+
+	@Inject
+	FailedPaymentTransactionProcessor failedPaymentTransactionProcessor;
+	
+	AcquirerConfiguration acquirerConfiguration;
+	
+	ClosePaymentRequest closePaymentRequestOK;
+	
+	ClosePaymentRequest closePaymentRequestKO;
+	
+	private CountDownLatch lock = new CountDownLatch(1);
+	
+	@InjectMock
+	@RestClient
+    NodeRestService nodeRestService;
+	
+	@Test
+	void consume_200_OK() {
+		NodeClosePaymentResponse nodeClosePaymentResponse = new NodeClosePaymentResponse();
+		nodeClosePaymentResponse.setOutcome(Outcome.OK.name());
+		
+		Mockito
+		.when(nodeRestService.closePayment(Mockito.any()))
+		.thenReturn(Uni.createFrom().item(nodeClosePaymentResponse));
+		
+		acquirerConfiguration = PaymentTestData.getAcquirerConfiguration();
+		
+		closePaymentRequestOK = PaymentTestData.getClosePaymentRequest(true);
+		
+		NodeClosePaymentRequest nodeClosePaymentRequest = createNodeClosePaymentRequest(closePaymentRequestOK,acquirerConfiguration.getPspConfigForVerifyAndActivate());
+		
+		failedPaymentTransactionProcessor.consume(nodeClosePaymentRequest);
+
+		ArgumentCaptor<NodeClosePaymentRequest> captor = ArgumentCaptor.forClass(NodeClosePaymentRequest.class);
+		Mockito.verify(nodeRestService).closePayment(captor.capture());
+		Assertions.assertEquals("648fhg36s95jfg7DS",captor.getValue().getPaymentTokens().get(0));
+		Assertions.assertEquals(Outcome.OK.toString(), captor.getValue().getOutcome());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getPsp(), captor.getValue().getIdPsp());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getBroker(), captor.getValue().getIdBrokerPSP());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getChannel(), captor.getValue().getIdChannel());
+		Assertions.assertEquals(PaymentMethod.PAGOBANCOMAT.name(), captor.getValue().getPaymentMethod());
+		Assertions.assertEquals("517a4216840E461fB011036A0fd134E1", captor.getValue().getTransactionId());
+		Assertions.assertEquals(BigDecimal.valueOf(234234).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getTotalAmount());
+		Assertions.assertEquals(BigDecimal.valueOf(897).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getFee());
+		
+		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequestOK.getTimestampOp()).atZone(ZoneId.of("UTC"));
+		
+		Assertions.assertEquals(timestampOperation.format(DateTimeFormatter.ISO_INSTANT), captor.getValue().getTimestampOperation());
+		Assertions.assertNotNull(captor.getValue().getAdditionalPaymentInformations());
+		
+	}
+	
+	@Test
+	void consume_200_KO() {
+
+		NodeClosePaymentResponse nodeClosePaymentResponse = new NodeClosePaymentResponse();
+		nodeClosePaymentResponse.setOutcome(Outcome.KO.name());
+		
+		Mockito
+		.when(nodeRestService.closePayment(Mockito.any()))
+		.thenReturn(Uni.createFrom().item(nodeClosePaymentResponse));
+		
+		acquirerConfiguration = PaymentTestData.getAcquirerConfiguration();
+		closePaymentRequestKO = PaymentTestData.getClosePaymentRequest(false);
+		
+		NodeClosePaymentRequest nodeClosePaymentRequest = createNodeClosePaymentRequest(closePaymentRequestKO,acquirerConfiguration.getPspConfigForVerifyAndActivate());
+		
+		failedPaymentTransactionProcessor.consume(nodeClosePaymentRequest);
+		
+		try {
+			lock.await(10000, TimeUnit.MILLISECONDS);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		ArgumentCaptor<NodeClosePaymentRequest> captor = ArgumentCaptor.forClass(NodeClosePaymentRequest.class);
+		Mockito.verify(nodeRestService).closePayment(captor.capture());
+		Assertions.assertEquals("648fhg36s95jfg7DS",captor.getValue().getPaymentTokens().get(0));
+		Assertions.assertEquals(Outcome.KO.toString(), captor.getValue().getOutcome());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getPsp(), captor.getValue().getIdPsp());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getBroker(), captor.getValue().getIdBrokerPSP());
+		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getChannel(), captor.getValue().getIdChannel());
+		Assertions.assertEquals(PaymentMethod.PAGOBANCOMAT.name(), captor.getValue().getPaymentMethod());
+		Assertions.assertEquals("517a4216840E461fB011036A0fd134E1", captor.getValue().getTransactionId());
+		Assertions.assertEquals(BigDecimal.valueOf(234234).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getTotalAmount());
+		Assertions.assertEquals(BigDecimal.valueOf(897).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getFee());
+		
+		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequestKO.getTimestampOp()).atZone(ZoneId.of("UTC"));
+		
+		Assertions.assertEquals(timestampOperation.format(DateTimeFormatter.ISO_INSTANT), captor.getValue().getTimestampOperation());
+		Assertions.assertNotNull(captor.getValue().getAdditionalPaymentInformations());
+		
+	}
+	
+	private NodeClosePaymentRequest createNodeClosePaymentRequest(ClosePaymentRequest closePaymentRequest, PspConfiguration pspConfiguration) {
+
+		NodeClosePaymentRequest nodeClosePaymentRequest =
+				new NodeClosePaymentRequest();
+
+		nodeClosePaymentRequest.setPaymentTokens(closePaymentRequest.getPaymentTokens());
+		nodeClosePaymentRequest.setOutcome(closePaymentRequest.getOutcome());
+		nodeClosePaymentRequest.setIdPsp(pspConfiguration.getPsp());
+		nodeClosePaymentRequest.setIdBrokerPSP(pspConfiguration.getBroker());
+		nodeClosePaymentRequest.setIdChannel(pspConfiguration.getChannel());
+		nodeClosePaymentRequest.setPaymentMethod(closePaymentRequest.getPaymentMethod());
+		nodeClosePaymentRequest.setTransactionId(closePaymentRequest.getTransactionId());
+		// conversion from euro cents to euro
+		nodeClosePaymentRequest.setTotalAmount(new BigDecimal(closePaymentRequest.getTotalAmount()).divide(new BigDecimal(100), RoundingMode.HALF_DOWN));
+		nodeClosePaymentRequest.setFee(new BigDecimal(closePaymentRequest.getFee()).divide(new BigDecimal(100), RoundingMode.HALF_DOWN));
+		// transform the date from LocalDateTime to ZonedDateTime as requested by the closePayment on the node
+		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequest.getTimestampOp()).atZone(ZoneId.of("UTC"));
+		nodeClosePaymentRequest.setTimestampOperation(timestampOperation.format(DateTimeFormatter.ISO_INSTANT));
+
+		nodeClosePaymentRequest.setAdditionalPaymentInformations(new AdditionalPaymentInformations());
+
+		return nodeClosePaymentRequest;
+	}
+}

--- a/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/FailedPaymentTransactionProcessorTest.java
+++ b/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/FailedPaymentTransactionProcessorTest.java
@@ -4,19 +4,22 @@
 package it.gov.pagopa.swclient.mil.paymentnotice;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.concurrent.CountDownLatch;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import org.awaitility.Awaitility;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -25,7 +28,6 @@ import io.quarkus.test.junit.mockito.InjectMock;
 import io.smallrye.mutiny.Uni;
 import it.gov.pagopa.swclient.mil.paymentnotice.bean.ClosePaymentRequest;
 import it.gov.pagopa.swclient.mil.paymentnotice.bean.Outcome;
-import it.gov.pagopa.swclient.mil.paymentnotice.bean.PaymentMethod;
 import it.gov.pagopa.swclient.mil.paymentnotice.client.NodeRestService;
 import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.AcquirerConfiguration;
 import it.gov.pagopa.swclient.mil.paymentnotice.client.bean.AdditionalPaymentInformations;
@@ -36,51 +38,59 @@ import it.gov.pagopa.swclient.mil.paymentnotice.resource.FailedPaymentTransactio
 import it.gov.pagopa.swclient.mil.paymentnotice.util.PaymentTestData;
 
 @QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FailedPaymentTransactionProcessorTest {
 
 	@Inject
 	FailedPaymentTransactionProcessor failedPaymentTransactionProcessor;
-	
+
+	@InjectMock
+	@RestClient
+	NodeRestService nodeRestService;
+
 	AcquirerConfiguration acquirerConfiguration;
 	
 	ClosePaymentRequest closePaymentRequestOK;
 	
 	ClosePaymentRequest closePaymentRequestKO;
 	
-	private CountDownLatch lock = new CountDownLatch(1);
-	
-	@InjectMock
-	@RestClient
-    NodeRestService nodeRestService;
+	@BeforeAll
+	void createTestObjects() {
+
+		acquirerConfiguration = PaymentTestData.getAcquirerConfiguration();
+
+		closePaymentRequestOK = PaymentTestData.getClosePaymentRequest(true);
+
+		closePaymentRequestKO = PaymentTestData.getClosePaymentRequest(false);
+
+	}
 	
 	@Test
 	void consume_200_OK() {
+
 		NodeClosePaymentResponse nodeClosePaymentResponse = new NodeClosePaymentResponse();
 		nodeClosePaymentResponse.setOutcome(Outcome.OK.name());
 		
 		Mockito
 		.when(nodeRestService.closePayment(Mockito.any()))
 		.thenReturn(Uni.createFrom().item(nodeClosePaymentResponse));
-		
-		acquirerConfiguration = PaymentTestData.getAcquirerConfiguration();
-		
-		closePaymentRequestOK = PaymentTestData.getClosePaymentRequest(true);
-		
-		NodeClosePaymentRequest nodeClosePaymentRequest = createNodeClosePaymentRequest(closePaymentRequestOK,acquirerConfiguration.getPspConfigForVerifyAndActivate());
+
+		NodeClosePaymentRequest nodeClosePaymentRequest = createNodeClosePaymentRequest(closePaymentRequestOK,
+				acquirerConfiguration.getPspConfigForGetFeeAndClosePayment());
 		
 		failedPaymentTransactionProcessor.consume(nodeClosePaymentRequest);
 
 		ArgumentCaptor<NodeClosePaymentRequest> captor = ArgumentCaptor.forClass(NodeClosePaymentRequest.class);
 		Mockito.verify(nodeRestService).closePayment(captor.capture());
-		Assertions.assertEquals("648fhg36s95jfg7DS",captor.getValue().getPaymentTokens().get(0));
+		Assertions.assertEquals(closePaymentRequestOK.getPaymentTokens().get(0), captor.getValue().getPaymentTokens().get(0));
 		Assertions.assertEquals(Outcome.OK.toString(), captor.getValue().getOutcome());
 		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getPsp(), captor.getValue().getIdPsp());
 		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getBroker(), captor.getValue().getIdBrokerPSP());
 		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getChannel(), captor.getValue().getIdChannel());
-		Assertions.assertEquals(PaymentMethod.PAGOBANCOMAT.name(), captor.getValue().getPaymentMethod());
-		Assertions.assertEquals("517a4216840E461fB011036A0fd134E1", captor.getValue().getTransactionId());
-		Assertions.assertEquals(BigDecimal.valueOf(234234).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getTotalAmount());
-		Assertions.assertEquals(BigDecimal.valueOf(897).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getFee());
+		Assertions.assertEquals("CP", captor.getValue().getPaymentMethod());
+		Assertions.assertEquals(closePaymentRequestOK.getTransactionId(), captor.getValue().getTransactionId());
+		Assertions.assertEquals(closePaymentRequestOK.getTotalAmount(), captor.getValue().getTotalAmount().multiply(new BigDecimal(100)).toBigInteger());
+		Assertions.assertEquals(closePaymentRequestOK.getFee(), captor.getValue().getFee().multiply(new BigDecimal(100)).toBigInteger());
 		
 		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequestOK.getTimestampOp()).atZone(ZoneId.of("UTC"));
 		
@@ -96,33 +106,27 @@ class FailedPaymentTransactionProcessorTest {
 		nodeClosePaymentResponse.setOutcome(Outcome.KO.name());
 		
 		Mockito
-		.when(nodeRestService.closePayment(Mockito.any()))
-		.thenReturn(Uni.createFrom().item(nodeClosePaymentResponse));
-		
-		acquirerConfiguration = PaymentTestData.getAcquirerConfiguration();
-		closePaymentRequestKO = PaymentTestData.getClosePaymentRequest(false);
-		
-		NodeClosePaymentRequest nodeClosePaymentRequest = createNodeClosePaymentRequest(closePaymentRequestKO,acquirerConfiguration.getPspConfigForVerifyAndActivate());
+				.when(nodeRestService.closePayment(Mockito.any()))
+				.thenReturn(Uni.createFrom().item(nodeClosePaymentResponse));
+
+		NodeClosePaymentRequest nodeClosePaymentRequest = createNodeClosePaymentRequest(closePaymentRequestKO,
+				acquirerConfiguration.getPspConfigForGetFeeAndClosePayment());
 		
 		failedPaymentTransactionProcessor.consume(nodeClosePaymentRequest);
-		
-		try {
-			lock.await(10000, TimeUnit.MILLISECONDS);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
+
+		Awaitility.await().atLeast(15, TimeUnit.SECONDS);
 
 		ArgumentCaptor<NodeClosePaymentRequest> captor = ArgumentCaptor.forClass(NodeClosePaymentRequest.class);
 		Mockito.verify(nodeRestService).closePayment(captor.capture());
-		Assertions.assertEquals("648fhg36s95jfg7DS",captor.getValue().getPaymentTokens().get(0));
+		Assertions.assertEquals(closePaymentRequestKO.getPaymentTokens().get(0), captor.getValue().getPaymentTokens().get(0));
 		Assertions.assertEquals(Outcome.KO.toString(), captor.getValue().getOutcome());
 		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getPsp(), captor.getValue().getIdPsp());
 		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getBroker(), captor.getValue().getIdBrokerPSP());
 		Assertions.assertEquals(acquirerConfiguration.getPspConfigForGetFeeAndClosePayment().getChannel(), captor.getValue().getIdChannel());
-		Assertions.assertEquals(PaymentMethod.PAGOBANCOMAT.name(), captor.getValue().getPaymentMethod());
-		Assertions.assertEquals("517a4216840E461fB011036A0fd134E1", captor.getValue().getTransactionId());
-		Assertions.assertEquals(BigDecimal.valueOf(234234).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getTotalAmount());
-		Assertions.assertEquals(BigDecimal.valueOf(897).divide(new BigDecimal(100), RoundingMode.HALF_DOWN), captor.getValue().getFee());
+		Assertions.assertEquals("CP", captor.getValue().getPaymentMethod());
+		Assertions.assertEquals(closePaymentRequestKO.getTransactionId(), captor.getValue().getTransactionId());
+		Assertions.assertEquals(closePaymentRequestKO.getTotalAmount(), captor.getValue().getTotalAmount().multiply(new BigDecimal(100)).toBigInteger());
+		Assertions.assertEquals(closePaymentRequestKO.getFee(), captor.getValue().getFee().multiply(new BigDecimal(100)).toBigInteger());
 		
 		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequestKO.getTimestampOp()).atZone(ZoneId.of("UTC"));
 		
@@ -130,7 +134,7 @@ class FailedPaymentTransactionProcessorTest {
 		Assertions.assertNotNull(captor.getValue().getAdditionalPaymentInformations());
 		
 	}
-	
+
 	private NodeClosePaymentRequest createNodeClosePaymentRequest(ClosePaymentRequest closePaymentRequest, PspConfiguration pspConfiguration) {
 
 		NodeClosePaymentRequest nodeClosePaymentRequest =
@@ -141,11 +145,16 @@ class FailedPaymentTransactionProcessorTest {
 		nodeClosePaymentRequest.setIdPsp(pspConfiguration.getPsp());
 		nodeClosePaymentRequest.setIdBrokerPSP(pspConfiguration.getBroker());
 		nodeClosePaymentRequest.setIdChannel(pspConfiguration.getChannel());
-		nodeClosePaymentRequest.setPaymentMethod(closePaymentRequest.getPaymentMethod());
+
+		// remapping payment method based on property file
+		Optional<String> optPaymentMethodMapping = ConfigProvider.getConfig()
+				.getOptionalValue("node.paymentmethod.map." + closePaymentRequest.getPaymentMethod(), String.class);
+		nodeClosePaymentRequest.setPaymentMethod(optPaymentMethodMapping.orElse(closePaymentRequest.getPaymentMethod()));
+
 		nodeClosePaymentRequest.setTransactionId(closePaymentRequest.getTransactionId());
 		// conversion from euro cents to euro
-		nodeClosePaymentRequest.setTotalAmount(new BigDecimal(closePaymentRequest.getTotalAmount()).divide(new BigDecimal(100), RoundingMode.HALF_DOWN));
-		nodeClosePaymentRequest.setFee(new BigDecimal(closePaymentRequest.getFee()).divide(new BigDecimal(100), RoundingMode.HALF_DOWN));
+		nodeClosePaymentRequest.setTotalAmount(new BigDecimal(closePaymentRequest.getTotalAmount(), 2));
+		nodeClosePaymentRequest.setFee(new BigDecimal(closePaymentRequest.getFee(), 2));
 		// transform the date from LocalDateTime to ZonedDateTime as requested by the closePayment on the node
 		ZonedDateTime timestampOperation = LocalDateTime.parse(closePaymentRequest.getTimestampOp()).atZone(ZoneId.of("UTC"));
 		nodeClosePaymentRequest.setTimestampOperation(timestampOperation.format(DateTimeFormatter.ISO_INSTANT));

--- a/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/ManagePaymentResultTest.java
+++ b/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/ManagePaymentResultTest.java
@@ -1,5 +1,21 @@
 package it.gov.pagopa.swclient.mil.paymentnotice;
 
+import static io.restassured.RestAssured.given;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.InternalServerErrorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
@@ -12,19 +28,6 @@ import it.gov.pagopa.swclient.mil.paymentnotice.bean.ReceivePaymentStatusRequest
 import it.gov.pagopa.swclient.mil.paymentnotice.redis.PaymentService;
 import it.gov.pagopa.swclient.mil.paymentnotice.resource.PaymentResource;
 import it.gov.pagopa.swclient.mil.paymentnotice.util.PaymentTestData;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
-
-import javax.ws.rs.InternalServerErrorException;
-import java.util.List;
-import java.util.Map;
-
-import static io.restassured.RestAssured.given;
 
 @QuarkusTest
 @TestHTTPEndpoint(PaymentResource.class)
@@ -98,7 +101,10 @@ class ManagePaymentResultTest {
 			Assertions.assertEquals(paymentStatus.getPayments().get(i).getPaymentToken(), payment.getPaymentToken());
 		}
 
-		// TODO add check of clients
+		//check of milRestService clients
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		Mockito.verify(paymentService).get(captor.capture());
+		Assertions.assertEquals(TRANSACTION_ID,captor.getValue());
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
This PR contains the following changes:

-  Added PAYMENT_CARD as valid payment method in closePaymentNotice
-  Added remapping of payment method when calling node closePayment
-  Added logs for request/response of the node closePayment 
-  Fixed unit tests for close payment
