### PR TITLE
fix: Fixed creation of Location header in response of close API using property

### DIFF
--- a/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/resource/PaymentResource.java
+++ b/src/main/java/it/gov/pagopa/swclient/mil/paymentnotice/resource/PaymentResource.java
@@ -58,6 +58,7 @@ public class PaymentResource extends BasePaymentResource {
 	@ConfigProperty(name = "node.paymentmethod.map")
 	Map<String, String> nodePaymentMethodMap;
 
+
 	/**
 	 * The reactive REDIS client
 	 */
@@ -89,6 +90,11 @@ public class PaymentResource extends BasePaymentResource {
 	@ConfigProperty(name="paymentnotice.closepayment.retry-after", defaultValue = "30")
 	int closePaymentRetryAfter;
 
+	/**
+	 * The base URL for the location header returned by the closePayment (i.e. the API management base URL)
+	 */
+	@ConfigProperty(name="paymentnotice.closepayment.location.base-url")
+	String closePaymentLocationBaseURL;
 
 	/**
 	 * Closes a set of payment notices previously activated calling the
@@ -278,7 +284,7 @@ public class PaymentResource extends BasePaymentResource {
 				if (outcomeOk) {
 					closePaymentResponse.setOutcome(Outcome.OK);
 					responseBuilder
-							.location(URI.create("/payments/" + closePaymentRequest.getTransactionId()))
+							.location(URI.create(closePaymentLocationBaseURL + "/payments/" + closePaymentRequest.getTransactionId()))
 							.header("Retry-After", closePaymentRetryAfter)
 							.header("Max-Retry", closePaymentMaxRetry);
 				}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,7 +33,6 @@ quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{requestId}] [%p] [%c{
 
 quarkus.cxf.client."nodo".service-interface=it.gov.pagopa.pagopa_api.nodeforpsp.NodeForPsp
 
-#%dev.quarkus.cxf.client.node.client-endpoint-url=https://api.uat.platform.pagopa.it/nodo/node-for-psp/v1
 %dev.quarkus.cxf.client.node.client-endpoint-url=http://localhost:8088/nodo/node-for-psp/v1
 %dev.quarkus.cxf.client.node.features=org.apache.cxf.ext.logging.LoggingFeature
 
@@ -125,12 +124,15 @@ quarkus.cxf.client."nodo".service-interface=it.gov.pagopa.pagopa_api.nodeforpsp.
 
 %dev.paymentnotice.closepayment.max-retry=3
 %dev.paymentnotice.closepayment.retry-after=30
+%dev.paymentnotice.closepayment.location.base-url=https://mil-d-apim.azure-api.net/mil-payment-notice
 
 %test.paymentnotice.closepayment.max-retry=3
 %test.paymentnotice.closepayment.retry-after=30
+%test.paymentnotice.closepayment.location.base-url=https://mil-d-apim.azure-api.net/mil-payment-notice
 
 %prod.paymentnotice.closepayment.max-retry=${paymentnotice.closepayment.max-retry}
 %prod.paymentnotice.closepayment.retry-after=${paymentnotice.closepayment.retry-after}
+%prod.paymentnotice.closepayment.location.base-url=${paymentnotice.closepayment.location.base-url}
 
 %dev.paymentnotice.activatepayment.expiration-time=30000
 %test.paymentnotice.activatepayment.expiration-time=30000

--- a/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/it/IntegrationTestProfile.java
+++ b/src/test/java/it/gov/pagopa/swclient/mil/paymentnotice/it/IntegrationTestProfile.java
@@ -30,6 +30,7 @@ public class IntegrationTestProfile implements QuarkusTestProfile {
         configOverrides.put("node-rest-client-subscription-key", "abc");
         configOverrides.put("mil-rest-client-subscription-key", "abc");
         configOverrides.put("mil-acquirer-conf-version", "1.0.0");
+        configOverrides.put("paymentnotice.closepayment.location.base-url", "https://mil-d-apim.azure-api.net/mil-payment-notice");
 
         return configOverrides;
     }

--- a/src/test/postman/Payment_Notice_Service.postman_collection.json
+++ b/src/test/postman/Payment_Notice_Service.postman_collection.json
@@ -9655,7 +9655,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"outcome\": \"OK\",\r\n    \"paymentTokens\": [\r\n        \"{{paymentToken}}\"\r\n    ],\r\n    \"paymentMethod\": \"PAGOBANCOMAT\",\r\n    \"transactionId\": \"{{transactionId}}\",\r\n    \"totalAmount\": {{totalAmount}},\r\n    \"fee\": {{fee}},\r\n    \"timestampOp\": \"{{timestampOp}}\"\r\n}",
+									"raw": "{\r\n    \"outcome\": \"OK\",\r\n    \"paymentTokens\": [\r\n        \"{{paymentToken}}\"\r\n    ],\r\n    \"paymentMethod\": \"{{paymentMethod}}\",\r\n    \"transactionId\": \"{{transactionId}}\",\r\n    \"totalAmount\": {{totalAmount}},\r\n    \"fee\": {{fee}},\r\n    \"timestampOp\": \"{{timestampOp}}\"\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10205,7 +10205,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n    \"outcome\": \"OK\",\r\n    \"paymentTokens\": [\r\n        \"{{paymentToken}}\"\r\n    ],\r\n    \"paymentMethod\": \"PAGOBANCOMAT\",\r\n    \"transactionId\": \"{{transactionId}}\",\r\n    \"totalAmount\": {{totalAmount}},\r\n    \"fee\": {{fee}},\r\n    \"timestampOp\": \"{{timestampOp}}\"\r\n}",
+									"raw": "{\r\n    \"outcome\": \"OK\",\r\n    \"paymentTokens\": [\r\n        \"{{paymentToken}}\"\r\n    ],\r\n    \"paymentMethod\": \"{{paymentMethod}}\",\r\n    \"transactionId\": \"{{transactionId}}\",\r\n    \"totalAmount\": {{totalAmount}},\r\n    \"fee\": {{fee}},\r\n    \"timestampOp\": \"{{timestampOp}}\"\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -10285,7 +10285,7 @@
 									"variable": [
 										{
 											"key": "transactionId",
-											"value": "bcb0e6ab48aa426c8e92625424a1321d"
+											"value": "{{transactionId}}"
 										}
 									]
 								}
@@ -10537,6 +10537,11 @@
 		{
 			"key": "fee",
 			"value": "100",
+			"type": "string"
+		},
+		{
+			"key": "paymentMethod",
+			"value": "PAYMENT_CARD",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
Added property paymentnotice.closepayment.location.base-url to be used in creating the Location header in response of the close payment API